### PR TITLE
Fix #7

### DIFF
--- a/src/babel.js
+++ b/src/babel.js
@@ -6,6 +6,7 @@ module.exports = babelJest.createTransformer({
 			'@babel/preset-typescript',
 			{
 				jsxPragma: 'h',
+				jsxPragmaFrag: 'Fragment',
 			},
 		],
 		'@babel/preset-env',


### PR DESCRIPTION
To avoid Babel from removing the Fragment import, it needs to be set as jsxPragmaFrag.