### PR TITLE
Use automatic runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Jest preset containing all required configuration for writing tests for [preact]
 Features:
 
 - Transpiles JSX to `h()`
-- Aaliases for `"react"` imports to point to `preact/compat`
+- Aliases for `react` imports to point to `preact/compat`
 - Automatically serialize Preact `VNodes` in snapshots
 - Stub style imports (`.css`, `.less`, `.sass/scss`, etc)
 - Add typeahead preview for filtering in jest's watch mode
@@ -28,6 +28,29 @@ module.exports = {
 	preset: 'jest-preset-preact',
 };
 ```
+
+You can override the default Babel config by providing your own Babel config file:
+
+```js
+// babel.config.js
+module.exports = {
+  env: {
+    test: {
+      plugins: [
+        [
+          "@babel/plugin-transform-react-jsx",
+          {
+            runtime: "automatic",
+            importSource: "preact"
+          }
+        ]
+      ]
+    }
+  }
+}
+```
+
+This, for example, would enable the runtime JSX transform instead of the classic.
 
 ## License
 

--- a/src/babel.js
+++ b/src/babel.js
@@ -15,7 +15,8 @@ module.exports = babelJest.default.createTransformer({
 		[
 			'@babel/plugin-transform-react-jsx',
 			{
-				runtime: 'automatic'
+				runtime: 'automatic',
+				importSource: 'preact'
 			},
 		],
 		'@babel/plugin-proposal-class-properties',

--- a/src/babel.js
+++ b/src/babel.js
@@ -3,7 +3,8 @@ const babel = require('@babel/core');
 
 // Use config file if present.
 const config = babel.loadPartialConfig();
-const options = {
+
+module.exports = babelJest.default.createTransformer({
 	presets: [
 		[
 			'@babel/preset-typescript',
@@ -27,9 +28,4 @@ const options = {
 	babelrc: false,
 	configFile: false,
 	overrides: config.files.size ? [config.options] : [],
-};
-
-module.exports = {
-	...babelJest.default,
-	createTransformer: () => babelJest.default.createTransformer(options),
-};
+});

--- a/src/babel.js
+++ b/src/babel.js
@@ -15,8 +15,7 @@ module.exports = babelJest.default.createTransformer({
 		[
 			'@babel/plugin-transform-react-jsx',
 			{
-				runtime: 'automatic',
-				importSource: 'preact'
+				runtime: 'automatic'
 			},
 		],
 		'@babel/plugin-proposal-class-properties',

--- a/src/babel.js
+++ b/src/babel.js
@@ -1,26 +1,36 @@
 const babelJest = require('babel-jest');
+const babel = require('@babel/core');
 
-module.exports = babelJest.default.createTransformer({
-	presets: [
-		[
-			'@babel/preset-typescript',
-			{
-				jsxPragma: 'h',
-				jsxPragmaFrag: 'Fragment',
-			},
+// Use config file if present.
+const config = babel.loadPartialConfig();
+const options = config.files.size
+	? config.options
+	: {
+		presets: [
+			[
+				'@babel/preset-typescript',
+				{
+					jsxPragma: 'h',
+					jsxPragmaFrag: 'Fragment',
+				},
+			],
+			'@babel/preset-env',
 		],
-		'@babel/preset-env',
-	],
-	plugins: [
-		[
-			'@babel/plugin-transform-react-jsx',
-			{
-				pragma: 'h',
-				pragmaFrag: 'Fragment',
-			},
+		plugins: [
+			[
+				'@babel/plugin-transform-react-jsx',
+				{
+					pragma: 'h',
+					pragmaFrag: 'Fragment',
+				},
+			],
+			'@babel/plugin-proposal-class-properties',
 		],
-		'@babel/plugin-proposal-class-properties',
-	],
-	babelrc: false,
-	configFile: false,
-});
+		babelrc: false,
+		configFile: false,
+	};
+
+module.exports = {
+	...babelJest.default,
+	createTransformer: () => babelJest.default.createTransformer(options),
+};

--- a/src/babel.js
+++ b/src/babel.js
@@ -3,9 +3,7 @@ const babel = require('@babel/core');
 
 // Use config file if present.
 const config = babel.loadPartialConfig();
-const options = config.files.size
-	? config.options
-	: {
+const options = {
 		presets: [
 			[
 				'@babel/preset-typescript',
@@ -28,6 +26,11 @@ const options = config.files.size
 		],
 		babelrc: false,
 		configFile: false,
+		overrides: config.files.size
+		? [
+			config.options,
+		]
+		: [],
 	};
 
 module.exports = {

--- a/src/babel.js
+++ b/src/babel.js
@@ -15,7 +15,8 @@ module.exports = babelJest.default.createTransformer({
 		[
 			'@babel/plugin-transform-react-jsx',
 			{
-				runtime: 'automatic'
+				pragma: 'h',
+				pragmaFrag: 'Fragment',
 			},
 		],
 		'@babel/plugin-proposal-class-properties',

--- a/src/babel.js
+++ b/src/babel.js
@@ -15,8 +15,7 @@ module.exports = babelJest.default.createTransformer({
 		[
 			'@babel/plugin-transform-react-jsx',
 			{
-				pragma: 'h',
-				pragmaFrag: 'Fragment',
+				runtime: 'automatic'
 			},
 		],
 		'@babel/plugin-proposal-class-properties',

--- a/src/babel.js
+++ b/src/babel.js
@@ -4,34 +4,30 @@ const babel = require('@babel/core');
 // Use config file if present.
 const config = babel.loadPartialConfig();
 const options = {
-		presets: [
-			[
-				'@babel/preset-typescript',
-				{
-					jsxPragma: 'h',
-					jsxPragmaFrag: 'Fragment',
-				},
-			],
-			'@babel/preset-env',
+	presets: [
+		[
+			'@babel/preset-typescript',
+			{
+				jsxPragma: 'h',
+				jsxPragmaFrag: 'Fragment',
+			},
 		],
-		plugins: [
-			[
-				'@babel/plugin-transform-react-jsx',
-				{
-					pragma: 'h',
-					pragmaFrag: 'Fragment',
-				},
-			],
-			'@babel/plugin-proposal-class-properties',
+		'@babel/preset-env',
+	],
+	plugins: [
+		[
+			'@babel/plugin-transform-react-jsx',
+			{
+				pragma: 'h',
+				pragmaFrag: 'Fragment',
+			},
 		],
-		babelrc: false,
-		configFile: false,
-		overrides: config.files.size
-		? [
-			config.options,
-		]
-		: [],
-	};
+		'@babel/plugin-proposal-class-properties',
+	],
+	babelrc: false,
+	configFile: false,
+	overrides: config.files.size ? [config.options] : [],
+};
 
 module.exports = {
 	...babelJest.default,


### PR DESCRIPTION
Uses the `runtime: "automatic"` setting for
`@babel/plugin-transform-react-jsx` so that
`h` is automatically imported for `JSX`
transpilation.

Is supposed to also automatically import
`Fragment`, but in brief testing on existing
project, does not do so.

Fixes #12