### PR TITLE
Allow preact-render-to-string 6.x in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 	"peerDependencies": {
 		"jest": "27.x || 28.x || 29.x",
 		"preact": "10.x",
-		"preact-render-to-string": "5.x"
+		"preact-render-to-string": "5.x || 6.x"
 	},
 	"files": [
 		"src/",


### PR DESCRIPTION
Hi team! I was using this package in a new project, and noticed it throws peer dependency errors due to the preact-render-to-string@5.x requirement. I hope this fix is acceptable.